### PR TITLE
Remove double forward slash on rendering file URL

### DIFF
--- a/components/Content.tsx
+++ b/components/Content.tsx
@@ -116,7 +116,7 @@ export default function Content(props) {
                 <th className={styles.heading}>CID</th>
               </tr>
               {selectedBucket.items.map((i) => {
-                const url = `https://ipfs.io/${i.path}`;
+                const url = `https://ipfs.io${i.path}`;
                 return (
                   <tr key={i.path} className={styles.row}>
                     <td className={styles.cell}>{i.name}</td>

--- a/components/Content.tsx
+++ b/components/Content.tsx
@@ -116,7 +116,7 @@ export default function Content(props) {
                 <th className={styles.heading}>CID</th>
               </tr>
               {selectedBucket.items.map((i) => {
-                const url = `https://ipfs.io${i.path}`;
+                const url = "https://ipfs.io" + i.path;
                 return (
                   <tr key={i.path} className={styles.row}>
                     <td className={styles.cell}>{i.name}</td>


### PR DESCRIPTION
I noticed that the file URL had a double forward slash. This is because the API is returning the path with a leading slash, and the Next.js app is concatenating the path to the IPFS URL, which has a trailing slash.

````js
const url = `https://ipfs.io/${i.path}`;

// Being "path" /cid/file, the resulting url would be https://ipfs.io//cid/file
````


I have concatenated the values this way since I consider it more legible:
````js
// Based on codebase
const url = `https://ipfs.io${i.path}`;

// Enhancing legibility - Proposed solution
const url = "https://ipfs.io" + i.path;
````